### PR TITLE
Update ish_kill_tracker.script

### DIFF
--- a/gamedata/scripts/ish_kill_tracker.script
+++ b/gamedata/scripts/ish_kill_tracker.script
@@ -14,7 +14,7 @@ function add_dot(victim, killer)
     end
 
     if db.actor and killer:name() == db.actor:name() and has_pda() then
-        level.map_add_object_spot_ser(victim:id(), "deadbody_location")
+        level.map_add_object_spot_ser(victim:id(), "deadbody_location","")
     end
 end
 


### PR DESCRIPTION
add missing third parameter. 

parameter mismatch has a chance to lock up the lua thread resulting in no further execution of the death callback for this npc/monster